### PR TITLE
Add Jellyfin API settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -9,5 +9,7 @@
     "user_name": "Human",
     "language": "English",
     "chunk_size": 256,
-    "chunk_overlap": 64
+    "chunk_overlap": 64,
+    "api_url": "http://localhost:1865",
+    "api_key": ""
 }

--- a/settings.py
+++ b/settings.py
@@ -42,6 +42,8 @@ You answer Human with a focus on the following context.
     language: Languages = Languages.English
     chunk_size: int = 256
     chunk_overlap: int = 64
+    api_url: str = "http://localhost:1865"
+    api_key: str = ""
 
     @field_validator("episodic_memory_threshold")
     @classmethod


### PR DESCRIPTION
## Summary
- add `api_url` and `api_key` fields to plugin settings model
- update default `settings.json` with API fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f5f74f558832e8ca1b328ccbcb089